### PR TITLE
feat: modo debug e adicionado primeiro cenário

### DIFF
--- a/tests/example.spec.js
+++ b/tests/example.spec.js
@@ -1,19 +1,15 @@
 // @ts-check
 const { test, expect } = require('@playwright/test');
 
-test('has title', async ({ page }) => {
-  await page.goto('https://playwright.dev/');
-
-  // Expect a title "to contain" a substring.
-  await expect(page).toHaveTitle(/Playwright/);
-});
-
-test('get started link', async ({ page }) => {
-  await page.goto('https://playwright.dev/');
-
-  // Click the get started link.
-  await page.getByRole('link', { name: 'Get started' }).click();
-
-  // Expects page to have a heading with the name of Installation.
-  await expect(page.getByRole('heading', { name: 'Installation' })).toBeVisible();
+test('Login com sucesso', async ({ page }) => {
+    await page.goto('https://automationpratice.com.br/');
+    await page.getByRole('link', { name: ' Login' }).click();
+    await page.getByRole('heading', { name: 'Login' }).click();
+    await page.locator('#user').click();
+    await page.locator('#user').fill('teste@teste.com');
+    await page.locator('#password').click();
+    await page.locator('#password').fill('123456');
+    await page.getByRole('button', { name: 'login' }).click();
+    await page.getByRole('heading', { name: 'Login realizado' }).click();
+    await page.getByText('Olá, teste@teste.com').click();
 });


### PR DESCRIPTION
**O que foi aprendido?**

O modo debug no Playwright ajuda a entender o que está acontecendo durante a execução de um teste. Ele permite que você "pause" os testes em pontos específicos e veja exatamente o que está acontecendo na página.

Alguns pontos interessantes sobre o modo debug:

- **Pausar a execução:** quando o modo debug está ativo, o Playwright pausa os testes em cada etapa, permitindo que você veja como a página está se comportando em tempo real. Isso ajuda a encontrar problemas como cliques errados ou elementos que não aparecem como esperado.

- **Ferramentas do navegador:** enquanto o teste está pausado, você pode usar as ferramentas de desenvolvedor (inspecionar elementos, console do navegador, etc.) para analisar a página e descobrir o que pode estar causando problemas.

- **Interação manual:** durante o modo debug, você pode interagir manualmente com a página – clicar em botões, preencher formulários – para testar e ver se o comportamento está correto.