### PR TITLE
feat: emulando devices

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -43,26 +43,26 @@ module.exports = defineConfig({
       use: { ...devices['Desktop Firefox'] },
     },
 
-    {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
-    },
+    // {
+    //   name: 'webkit',
+    //   use: { ...devices['Desktop Safari'] },
+    // },
 
     /* Test against mobile viewports. */
-    // {
-    //   name: 'Mobile Chrome',
-    //   use: { ...devices['Pixel 5'] },
-    // },
+    {
+      name: 'Mobile Chrome',
+      use: { ...devices['Pixel 5'] },
+    },
     // {
     //   name: 'Mobile Safari',
     //   use: { ...devices['iPhone 12'] },
     // },
 
     /* Test against branded browsers. */
-    // {
-    //   name: 'Microsoft Edge',
-    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
-    // },
+    {
+      name: 'Microsoft Edge',
+      use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    },
     // {
     //   name: 'Google Chrome',
     //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },

--- a/tests/register_user.spec.js
+++ b/tests/register_user.spec.js
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-test('test', async ({ page }) => {
+test('Registro de usuário com sucesso', async ({ page }) => {
   await page.goto('https://automationpratice.com.br/');
   await page.getByRole('link', { name: ' Cadastro' }).click();
   await page.locator('#user').click();


### PR DESCRIPTION
**O que foi aprendido?**

Emular dispositivos (ou devices) no Playwright é uma maneira de simular como seu site ou aplicação seria visualizado em diferentes dispositivos, como celulares ou navegadores específicos. Isso é útil para testar a responsividade e o comportamento do seu site em diferentes cenários.
