### PR TITLE
feat: resoluções diferentes de tela

### DIFF
--- a/tests/register_user.spec.js
+++ b/tests/register_user.spec.js
@@ -1,5 +1,9 @@
 import { test, expect } from '@playwright/test';
 
+test.use({
+    viewport: { width: 1600, height: 1200 },
+});
+
 test('Registro de usuário com sucesso', async ({ page }) => {
   await page.goto('https://automationpratice.com.br/');
   await page.getByRole('link', { name: ' Cadastro' }).click();


### PR DESCRIPTION
**O que foi aprendido?**

O viewport no Playwright define o tamanho da "janela" do navegador onde o teste será executado, ou seja, ele simula o tamanho da tela de um dispositivo ou navegador. Isso é útil para verificar como sua aplicação se comporta em diferentes resoluções de tela.

Você pode configurar o viewport diretamente em seus testes usando a função `test.use()` no Playwright, que permite definir um "contexto" específico para os testes. Isso pode ser feito em cada teste ou globalmente, dependendo de como você quer aplicar a configuração.