### PR TITLE
3 geolocalizacao

### DIFF
--- a/tests/geolocation.spec.js
+++ b/tests/geolocation.spec.js
@@ -1,0 +1,24 @@
+import { expect, test } from '@playwright/test';
+
+test.use({
+    geolocation: { longitude: 142.702789, latitude: -20.917574 }, // Coordenadas de Queensland
+    permissions: ['geolocation'], // Permissão para usar a geolocalização
+});
+
+test('Testar geolocalização no Google Maps para Queensland', async ({ page }) => {
+    // Acessa o Google Maps
+    await page.goto('https://www.google.com/maps');
+
+    // Clica no botão "Minha localização"
+    await page.getByLabel('Mostrar seu local').click();
+
+    // Espera um tempo para que o mapa centralize em Queensland
+    await page.waitForTimeout(3000);
+
+    // Verifica se o mapa carregou e centralizou em Queensland
+    const url = page.url();
+    console.log('URL do Google Maps:', url);
+
+    // Verifica se o URL contém as coordenadas de Queensland
+    await expect(url).toContain('@-20.917574,142.702789');
+});

--- a/tests/login.spec.js
+++ b/tests/login.spec.js
@@ -1,5 +1,5 @@
 // @ts-check
-const { test, expect } = require('@playwright/test');
+import { test, expect } from '@playwright/test';
 
 test('Login com sucesso', async ({ page }) => {
     await page.goto('https://automationpratice.com.br/');


### PR DESCRIPTION
**O que foi aprendido?**

Geolocation (geolocalização):

- O Playwright permite que você simule uma localização específica definindo as coordenadas de latitude e longitude.

Permissions (permissões):

- Para que o site (neste caso, o Google Maps) possa acessar a localização simulada, você precisa garantir que as permissões de geolocalização estejam ativadas. Isso é feito com `permissions: ['geolocation']`.

Test:

- Dentro do teste, o Playwright irá simular a navegação para um site, e o site poderá acessar a localização definida no teste.