### PR TITLE
feat: scroll

### DIFF
--- a/tests/scroll.spec.js
+++ b/tests/scroll.spec.js
@@ -1,0 +1,10 @@
+import { test } from '@playwright/test';
+
+test('Scroll', async ({ page }) => {
+    await page.goto('https://automationpratice.com.br/');
+
+    const button = await page.getByRole('button', { name: 'Send Mail' });
+    await button.scrollIntoViewIfNeeded(); // Garante que um elemento esteja visível na área de visualização da página
+
+    await page.getByRole('link', { name: ' Login' }).click();
+});


### PR DESCRIPTION
**O que foi aprendido?**

O comando `await button.scrollIntoViewIfNeeded()`; é usado no Playwright (ou em scripts que controlam o navegador) para garantir que um elemento esteja visível na área de visualização da página (a área atualmente visível para o usuário) antes de interagir com ele.